### PR TITLE
[499698] - Remove restriction on unfaceted projects from Link dialog

### DIFF
--- a/org.eclipse.cft.server.ui/src/org/eclipse/cft/server/ui/internal/actions/MapToProjectOperation.java
+++ b/org.eclipse.cft.server.ui/src/org/eclipse/cft/server/ui/internal/actions/MapToProjectOperation.java
@@ -177,25 +177,6 @@ public class MapToProjectOperation implements ICloudFoundryOperation {
 					return false;
 				}
 				
-				// If a module is set as nonfaceted, we do not need to check it.
-				if(!CloudFoundryServer.isNonfacetedModule(appModule)) {
-				
-					// .. otherwise, all projects should be faceted.
-					IFacetedProject facetedProject;
-					try {
-						facetedProject = ProjectFacetsManager.create(potentialProject);
-						
-						if(facetedProject == null) {
-							// Unfaceted projects are not supported, so return false.
-							return false;
-						}					
-					} catch (CoreException e) {
-						// If an error occurs when attempting to convert an individual project, then
-						// it likely is not supported (for example, not faceted), so return false.
-						return false;
-					}
-				}
-				
 				// Allow mapping a project with the same name as the app. This
 				// case needs to be handled first before checking for other
 				// potentially unrelated


### PR DESCRIPTION
Currently, the Link dialog (MapToProjectOperation) will present a list of projects that can be linked. We previously added a filter that removes non-faceted projects from this list, but this filter is no longer required. Non-faceted projects are now properly handled elsewhere in the code, so we no longer need to restrict their use here.