### PR TITLE
[498849] - Improved application delegate framework

### DIFF
--- a/org.eclipse.cft.server.core/src/org/eclipse/cft/server/core/internal/CloudServerUtil.java
+++ b/org.eclipse.cft.server.core/src/org/eclipse/cft/server/core/internal/CloudServerUtil.java
@@ -25,8 +25,10 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.eclipse.cft.server.core.internal.client.CloudFoundryApplicationModule;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.osgi.util.NLS;
+import org.eclipse.wst.server.core.IModule;
 import org.eclipse.wst.server.core.IServer;
 import org.eclipse.wst.server.core.IServerType;
 import org.eclipse.wst.server.core.ServerCore;
@@ -111,6 +113,17 @@ public class CloudServerUtil {
 			return isCloudFoundryServerType(server.getServerType());
 		}
 		return false;
+	}
+
+	public static CloudFoundryApplicationModule getCloudFoundryApplicationModule(IModule module, IServer server)
+			throws CoreException {
+		CloudFoundryServer cloudServer = CloudServerUtil.getCloudServer(server);
+		CloudFoundryApplicationModule appModule = cloudServer.getExistingCloudModule(module);
+		if (appModule == null) {
+			throw CloudErrorUtil.toCoreException(NLS.bind(Messages.ApplicationDelegate_NO_CLOUD_MODULE_FOUND,
+					module.getName(), cloudServer.getServer().getId()));
+		}
+		return appModule;
 	}
 
 	/**

--- a/org.eclipse.cft.server.core/src/org/eclipse/cft/server/core/internal/Messages.java
+++ b/org.eclipse.cft.server.core/src/org/eclipse/cft/server/core/internal/Messages.java
@@ -293,6 +293,8 @@ public class Messages extends NLS {
 
 	public static String RestartOperation_STARTING_APP;
 	
+	public static String ERROR_StartOperation_UNSUPPORTED_MODULE_TYPE;
+	
 	public static String PUBLISHING_MODULE;
 
 	public static String StopApplicationOperation_STOPPING_APP;

--- a/org.eclipse.cft.server.core/src/org/eclipse/cft/server/core/internal/Messages.properties
+++ b/org.eclipse.cft.server.core/src/org/eclipse/cft/server/core/internal/Messages.properties
@@ -70,6 +70,7 @@ ERROR_EXISTING_APPLICATION_LOGS=Failed to fetch recent application logs for {0} 
 ERROR_APPLICATION_LOG_LISTENER=Failed to add application log listener for {0} - {1}
 ERROR_NO_MAPPED_APPLICATION_URLS=No mapped application URLs set in application deployment information.
 ERROR_HOST_TAKEN=Host name already in use. A different mapped application URL is required before pushing or starting the application.
+ERROR_StartOperation_UNSUPPORTED_MODULE_TYPE=Application archive could not be generated for application: {0}. Please verify that the module type for this application - {1} - is supported for deployment to the specified Cloud target: {2}.
 INVALID_CHARACTERS_ERROR=The entered name contains invalid characters
 WARNING_SELF_SIGNED_PROMPT_USER=Failed to connect to {0}, probably because the site is using a self-signed certificate. Do you want to trust this site anyway?
 TITLE_SELF_SIGNED_PROMPT_USER=Failed to connect

--- a/org.eclipse.cft.server.core/src/org/eclipse/cft/server/core/internal/application/ApplicationArchiverFactory.java
+++ b/org.eclipse.cft.server.core/src/org/eclipse/cft/server/core/internal/application/ApplicationArchiverFactory.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Pivotal Software, Inc. and others
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution. 
+ * 
+ * The Eclipse Public License is available at 
+ * 
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * and the Apache License v2.0 is available at 
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * You may elect to redistribute this code under either of these licenses.
+ *  
+ *  Contributors:
+ *     Pivotal Software, Inc. - initial API and implementation
+ ********************************************************************************/
+package org.eclipse.cft.server.core.internal.application;
+
+import org.eclipse.cft.server.core.internal.CloudFoundryPlugin;
+import org.eclipse.cft.server.core.internal.CloudFoundryServer;
+import org.eclipse.cft.server.core.internal.CloudServerUtil;
+import org.eclipse.cft.server.core.internal.client.CloudFoundryApplicationModule;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.wst.server.core.IModule;
+import org.eclipse.wst.server.core.IServer;
+
+public class ApplicationArchiverFactory {
+
+	public ApplicationArchiverFactory() {
+
+	}
+
+	public ICloudFoundryArchiver getWarApplicationArchiver() {
+		return new WarApplicationArchiver();
+	}
+
+	public ICloudFoundryArchiver getManifestApplicationArchiver() {
+		return new ManifestApplicationArchiver();
+	}
+
+	/**
+	 * True if the given module can be archived using the framework's default
+	 * Manifest archiver. False otherwise (e.g. no associated accessible
+	 * project, or project for the module has no manifest.yml file).
+	 * @param module
+	 * @param server
+	 * @return
+	 */
+	public boolean supportsManifestArchiving(IModule module, IServer server) {
+		try {
+			CloudFoundryApplicationModule appModule = CloudServerUtil.getCloudFoundryApplicationModule(module, server);
+			CloudFoundryServer cloudServer = CloudServerUtil.getCloudServer(server);
+			if (appModule != null && cloudServer != null) {
+				ManifestParser parser = new ManifestParser(appModule, cloudServer);
+				return parser.hasManifest();
+			}
+		}
+		catch (CoreException e) {
+			CloudFoundryPlugin.logError(e);
+		}
+		return false;
+	}
+}

--- a/org.eclipse.cft.server.core/src/org/eclipse/cft/server/core/internal/application/ApplicationDelegate.java
+++ b/org.eclipse.cft.server.core/src/org/eclipse/cft/server/core/internal/application/ApplicationDelegate.java
@@ -23,16 +23,13 @@ package org.eclipse.cft.server.core.internal.application;
 
 import org.eclipse.cft.server.core.AbstractApplicationDelegate;
 import org.eclipse.cft.server.core.ApplicationDeploymentInfo;
-import org.eclipse.cft.server.core.internal.CloudErrorUtil;
 import org.eclipse.cft.server.core.internal.CloudFoundryServer;
 import org.eclipse.cft.server.core.internal.CloudServerUtil;
 import org.eclipse.cft.server.core.internal.CloudUtil;
-import org.eclipse.cft.server.core.internal.Messages;
 import org.eclipse.cft.server.core.internal.client.CloudFoundryApplicationModule;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
-import org.eclipse.osgi.util.NLS;
 import org.eclipse.wst.server.core.IModule;
 import org.eclipse.wst.server.core.IServer;
 
@@ -53,24 +50,11 @@ public abstract class ApplicationDelegate extends AbstractApplicationDelegate {
 
 		return deploymentInfo;
 	}
+	
 
-	/**
-	 * 
-	 * @param module
-	 * @param cloudServer
-	 * @return non-null {@link CloudFoundryApplicationModule}
-	 * @throws CoreException if application module could not be found (e.g. app
-	 * does not exist or server is out of synch)
-	 */
-	protected CloudFoundryApplicationModule getCloudFoundryApplicationModule(IModule module,
-			IServer server) throws CoreException {
-		CloudFoundryServer cloudServer = getCloudServer(server);
-		CloudFoundryApplicationModule appModule = cloudServer.getExistingCloudModule(module);
-		if (appModule == null) {
-			throw CloudErrorUtil.toCoreException(NLS.bind(Messages.ApplicationDelegate_NO_CLOUD_MODULE_FOUND,
-					module.getName(), cloudServer.getServer().getId()));
-		}
-		return appModule;
+	protected CloudFoundryApplicationModule getCloudFoundryApplicationModule(IModule module, IServer server)
+			throws CoreException {
+		return CloudServerUtil.getCloudFoundryApplicationModule(module, server);
 	}
 
 	@Override
@@ -79,13 +63,12 @@ public abstract class ApplicationDelegate extends AbstractApplicationDelegate {
 	}
 
 	@Override
-	public ApplicationDeploymentInfo getExistingApplicationDeploymentInfo(IModule module,
-			IServer server) throws CoreException {
+	public ApplicationDeploymentInfo getExistingApplicationDeploymentInfo(IModule module, IServer server)
+			throws CoreException {
 		return CloudUtil
-				.parseApplicationDeploymentInfo(
-						getCloudFoundryApplicationModule(module, server).getApplication());
+				.parseApplicationDeploymentInfo(getCloudFoundryApplicationModule(module, server).getApplication());
 	}
-	
+
 	protected CloudFoundryServer getCloudServer(IServer server) throws CoreException {
 		return CloudServerUtil.getCloudServer(server);
 	}

--- a/org.eclipse.cft.server.core/src/org/eclipse/cft/server/core/internal/application/ICloudFoundryArchiver.java
+++ b/org.eclipse.cft.server.core/src/org/eclipse/cft/server/core/internal/application/ICloudFoundryArchiver.java
@@ -18,18 +18,18 @@
  *  Contributors:
  *     IBM Corporation - initial API and implementation
  ********************************************************************************/
-package org.eclipse.cft.server.standalone.core.internal.application;
+package org.eclipse.cft.server.core.internal.application;
 
 import org.eclipse.cft.server.core.CFApplicationArchive;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.wst.server.core.IModule;
 import org.eclipse.wst.server.core.IServer;
+import org.eclipse.wst.server.core.model.IModuleResource;
 
 public interface ICloudFoundryArchiver {
 
-	public void initialize(IModule module, IServer server) throws CoreException;
-
-	public CFApplicationArchive getApplicationArchive(IProgressMonitor monitor) throws CoreException;
+	public CFApplicationArchive getApplicationArchive(IModule module, IServer server, IModuleResource[] resources,
+			IProgressMonitor monitor) throws CoreException;
 
 }

--- a/org.eclipse.cft.server.core/src/org/eclipse/cft/server/core/internal/application/JavaWebApplicationDelegate.java
+++ b/org.eclipse.cft.server.core/src/org/eclipse/cft/server/core/internal/application/JavaWebApplicationDelegate.java
@@ -21,35 +21,19 @@
  ********************************************************************************/
 package org.eclipse.cft.server.core.internal.application;
 
-import java.io.File;
-import java.io.IOException;
 import java.util.Arrays;
-import java.util.zip.ZipException;
-import java.util.zip.ZipFile;
 
 import org.eclipse.cft.server.core.ApplicationDeploymentInfo;
 import org.eclipse.cft.server.core.CFApplicationArchive;
 import org.eclipse.cft.server.core.internal.ApplicationUrlLookupService;
 import org.eclipse.cft.server.core.internal.CloudApplicationURL;
-import org.eclipse.cft.server.core.internal.CloudErrorUtil;
 import org.eclipse.cft.server.core.internal.CloudFoundryPlugin;
-import org.eclipse.cft.server.core.internal.CloudFoundryProjectUtil;
-import org.eclipse.cft.server.core.internal.CloudFoundryServer;
-import org.eclipse.cft.server.core.internal.CloudUtil;
 import org.eclipse.cft.server.core.internal.Messages;
-import org.eclipse.cft.server.core.internal.client.CloudFoundryApplicationModule;
-import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Path;
-import org.eclipse.core.runtime.Status;
-import org.eclipse.osgi.util.NLS;
 import org.eclipse.wst.server.core.IModule;
 import org.eclipse.wst.server.core.IServer;
-import org.eclipse.wst.server.core.internal.Server;
 import org.eclipse.wst.server.core.model.IModuleResource;
 
 /**
@@ -86,29 +70,8 @@ public class JavaWebApplicationDelegate extends ApplicationDelegate {
 	@Override
 	public CFApplicationArchive getApplicationArchive(IModule module, IServer server, IModuleResource[] moduleResources,
 			IProgressMonitor monitor) throws CoreException {
-
-		CloudFoundryApplicationModule appModule = getCloudFoundryApplicationModule(module, server);
-		CloudFoundryServer cloudServer = getCloudServer(server);
-		CFApplicationArchive manifestArchive = getArchiveFromManifest(appModule, cloudServer);
-		if (manifestArchive != null) {
-			return manifestArchive;
-		}
-		try {
-			File warFile = CloudUtil.createWarFile(new IModule[] { appModule.getLocalModule() },
-					(Server) cloudServer.getServer(), monitor);
-
-			CloudFoundryPlugin.trace("War file " + warFile.getName() + " created"); //$NON-NLS-1$ //$NON-NLS-2$
-
-			return new ZipArchive(new ZipFile(warFile));
-		}
-		catch (Exception e) {
-			throw new CoreException(new Status(IStatus.ERROR, CloudFoundryPlugin.PLUGIN_ID,
-					"Failed to create war file. " + //$NON-NLS-1$
-							"\nApplication: " + appModule.getApplication().getName() + //$NON-NLS-1$
-							"\nModule: " + appModule.getName() + //$NON-NLS-1$
-							"\nException: " + e.getMessage(), //$NON-NLS-1$
-					e));
-		}
+		return ApplicationRegistry.getArchiverFactory().getWarApplicationArchiver().getApplicationArchive(module,
+				server, moduleResources, monitor);
 	}
 
 	@Override
@@ -148,60 +111,4 @@ public class JavaWebApplicationDelegate extends ApplicationDelegate {
 		return info;
 	}
 
-	public static CFApplicationArchive getArchiveFromManifest(CloudFoundryApplicationModule appModule,
-			CloudFoundryServer cloudServer) throws CoreException {
-		String archivePath = null;
-		ManifestParser parser = new ManifestParser(appModule, cloudServer);
-		// Read the path again instead of deployment info, as a user may be
-		// correcting the path after the module was creating and simply
-		// attempting to push it again without the
-		// deployment wizard
-		if (parser.hasManifest()) {
-			archivePath = parser.getApplicationProperty(null, ManifestParser.PATH_PROP);
-		}
-
-		File packagedFile = null;
-		if (archivePath != null) {
-			// Only support paths that point to archive files
-			IPath path = new Path(archivePath);
-			if (path.getFileExtension() != null) {
-				// Check if it is project relative first
-				IFile projectRelativeFile = null;
-				IProject project = CloudFoundryProjectUtil.getProject(appModule);
-
-				if (project != null) {
-					projectRelativeFile = project.getFile(archivePath);
-				}
-
-				if (projectRelativeFile != null && projectRelativeFile.exists()) {
-					packagedFile = projectRelativeFile.getLocation().toFile();
-				}
-				else {
-					// See if it is an absolute path
-					File absoluteFile = new File(archivePath);
-					if (absoluteFile.exists() && absoluteFile.canRead()) {
-						packagedFile = absoluteFile;
-					}
-				}
-			}
-			// If a path is specified but no file found stop further deployment
-			if (packagedFile == null) {
-				String message = NLS.bind(Messages.JavaWebApplicationDelegate_ERROR_FILE_NOT_FOUND_MANIFEST_YML,
-						archivePath);
-				throw CloudErrorUtil.toCoreException(message);
-			}
-			else {
-				try {
-					return new ZipArchive(new ZipFile(packagedFile));
-				}
-				catch (ZipException e) {
-					throw CloudErrorUtil.toCoreException(e);
-				}
-				catch (IOException e) {
-					throw CloudErrorUtil.toCoreException(e);
-				}
-			}
-		}
-		return null;
-	}
 }

--- a/org.eclipse.cft.server.core/src/org/eclipse/cft/server/core/internal/application/ManifestApplicationArchiver.java
+++ b/org.eclipse.cft.server.core/src/org/eclipse/cft/server/core/internal/application/ManifestApplicationArchiver.java
@@ -1,0 +1,117 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Pivotal Software, Inc. and others
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution. 
+ * 
+ * The Eclipse Public License is available at 
+ * 
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * and the Apache License v2.0 is available at 
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * You may elect to redistribute this code under either of these licenses.
+ *  
+ *  Contributors:
+ *     Pivotal Software, Inc. - initial API and implementation
+ ********************************************************************************/
+package org.eclipse.cft.server.core.internal.application;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.zip.ZipException;
+import java.util.zip.ZipFile;
+
+import org.eclipse.cft.server.core.CFApplicationArchive;
+import org.eclipse.cft.server.core.internal.CloudErrorUtil;
+import org.eclipse.cft.server.core.internal.CloudFoundryProjectUtil;
+import org.eclipse.cft.server.core.internal.CloudFoundryServer;
+import org.eclipse.cft.server.core.internal.CloudServerUtil;
+import org.eclipse.cft.server.core.internal.Messages;
+import org.eclipse.cft.server.core.internal.client.CloudFoundryApplicationModule;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.osgi.util.NLS;
+import org.eclipse.wst.server.core.IModule;
+import org.eclipse.wst.server.core.IServer;
+import org.eclipse.wst.server.core.model.IModuleResource;
+
+/**
+ * Reads an application archiving (e.g. jar or war file) from the "path"
+ * property in an application's manifest.yml, if it exists in the application's
+ * project.
+ */
+public class ManifestApplicationArchiver implements ICloudFoundryArchiver {
+
+	@Override
+	public CFApplicationArchive getApplicationArchive(IModule module, IServer server, IModuleResource[] resources,
+			IProgressMonitor monitor) throws CoreException {
+		CloudFoundryServer cloudServer = CloudServerUtil.getCloudServer(server);
+		CloudFoundryApplicationModule appModule = CloudServerUtil.getCloudFoundryApplicationModule(module, server);
+		return getArchiveFromManifest(appModule, cloudServer);
+	}
+
+	public CFApplicationArchive getArchiveFromManifest(CloudFoundryApplicationModule appModule,
+			CloudFoundryServer cloudServer) throws CoreException {
+		String archivePath = null;
+		ManifestParser parser = new ManifestParser(appModule, cloudServer);
+		// Read the path again instead of deployment info, as a user may be
+		// correcting the path after the module was creating and simply
+		// attempting to push it again without the
+		// deployment wizard
+		if (parser.hasManifest()) {
+			archivePath = parser.getApplicationProperty(null, ManifestParser.PATH_PROP);
+		}
+
+		File packagedFile = null;
+		if (archivePath != null) {
+			// Only support paths that point to archive files
+			IPath path = new Path(archivePath);
+			if (path.getFileExtension() != null) {
+				// Check if it is project relative first
+				IFile projectRelativeFile = null;
+				IProject project = CloudFoundryProjectUtil.getProject(appModule);
+
+				if (project != null) {
+					projectRelativeFile = project.getFile(archivePath);
+				}
+
+				if (projectRelativeFile != null && projectRelativeFile.exists()) {
+					packagedFile = projectRelativeFile.getLocation().toFile();
+				}
+				else {
+					// See if it is an absolute path
+					File absoluteFile = new File(archivePath);
+					if (absoluteFile.exists() && absoluteFile.canRead()) {
+						packagedFile = absoluteFile;
+					}
+				}
+			}
+			// If a path is specified but no file found stop further deployment
+			if (packagedFile == null) {
+				String message = NLS.bind(Messages.JavaWebApplicationDelegate_ERROR_FILE_NOT_FOUND_MANIFEST_YML,
+						archivePath);
+				throw CloudErrorUtil.toCoreException(message);
+			}
+			else {
+				try {
+					return new ZipArchive(new ZipFile(packagedFile));
+				}
+				catch (ZipException e) {
+					throw CloudErrorUtil.toCoreException(e);
+				}
+				catch (IOException e) {
+					throw CloudErrorUtil.toCoreException(e);
+				}
+			}
+		}
+		return null;
+	}
+}

--- a/org.eclipse.cft.server.core/src/org/eclipse/cft/server/core/internal/application/WarApplicationArchiver.java
+++ b/org.eclipse.cft.server.core/src/org/eclipse/cft/server/core/internal/application/WarApplicationArchiver.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Pivotal Software, Inc. and others
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution. 
+ * 
+ * The Eclipse Public License is available at 
+ * 
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * and the Apache License v2.0 is available at 
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * You may elect to redistribute this code under either of these licenses.
+ *  
+ *  Contributors:
+ *     Pivotal Software, Inc. - initial API and implementation
+ ********************************************************************************/
+package org.eclipse.cft.server.core.internal.application;
+
+import java.io.File;
+import java.util.zip.ZipFile;
+
+import org.eclipse.cft.server.core.CFApplicationArchive;
+import org.eclipse.cft.server.core.internal.CloudErrorUtil;
+import org.eclipse.cft.server.core.internal.CloudFoundryPlugin;
+import org.eclipse.cft.server.core.internal.CloudFoundryServer;
+import org.eclipse.cft.server.core.internal.CloudServerUtil;
+import org.eclipse.cft.server.core.internal.CloudUtil;
+import org.eclipse.cft.server.core.internal.client.CloudFoundryApplicationModule;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.wst.server.core.IModule;
+import org.eclipse.wst.server.core.IServer;
+import org.eclipse.wst.server.core.internal.Server;
+import org.eclipse.wst.server.core.model.IModuleResource;
+
+public class WarApplicationArchiver implements ICloudFoundryArchiver {
+
+	@Override
+	public CFApplicationArchive getApplicationArchive(IModule module, IServer server, IModuleResource[] resources,
+			IProgressMonitor monitor) throws CoreException {
+		CloudFoundryApplicationModule appModule = CloudServerUtil.getCloudFoundryApplicationModule(module, server);
+
+		try {
+			if (server instanceof Server) {
+				File warFile = CloudUtil.createWarFile(new IModule[] { module }, (Server) server, monitor);
+
+				CloudFoundryPlugin.trace("War file " + warFile.getName() + " created"); //$NON-NLS-1$ //$NON-NLS-2$
+
+				return new ZipArchive(new ZipFile(warFile));
+			}
+			else {
+				throw CloudErrorUtil.toCoreException("Expected server: " + server.getId() + " to be of type: "
+						+ Server.class.getName() + ". Unable to generate WAR file and deploy the application to the selected server.");
+			}
+		}
+		catch (Exception e) {
+			throw new CoreException(new Status(IStatus.ERROR, CloudFoundryPlugin.PLUGIN_ID,
+					"Failed to create war file. " + //$NON-NLS-1$
+							"\nApplication: " + appModule.getDeployedApplicationName() + //$NON-NLS-1$
+							"\nModule: " + module.getName() + //$NON-NLS-1$
+							"\nException: " + e.getMessage(), //$NON-NLS-1$
+					e));
+		}
+	}
+
+}

--- a/org.eclipse.cft.server.core/src/org/eclipse/cft/server/core/internal/client/CloudFoundryServerBehaviour.java
+++ b/org.eclipse.cft.server.core/src/org/eclipse/cft/server/core/internal/client/CloudFoundryServerBehaviour.java
@@ -47,7 +47,6 @@ import org.cloudfoundry.client.lib.domain.CloudDomain;
 import org.cloudfoundry.client.lib.domain.CloudRoute;
 import org.cloudfoundry.client.lib.domain.CloudSpace;
 import org.cloudfoundry.client.lib.domain.InstancesInfo;
-import org.eclipse.cft.server.core.AbstractApplicationDelegate;
 import org.eclipse.cft.server.core.ApplicationDeploymentInfo;
 import org.eclipse.cft.server.core.CFApplicationArchive;
 import org.eclipse.cft.server.core.CFServiceInstance;
@@ -1750,14 +1749,11 @@ public class CloudFoundryServerBehaviour extends ServerBehaviourDelegate {
 		// resources. Use incremental publishing if
 		// possible.
 
-		AbstractApplicationDelegate delegate = ApplicationRegistry.getApplicationDelegate(cloudModule.getLocalModule());
+		
+		IModuleResource[] resources = getResources(modules);
 
-		CFApplicationArchive archive = null;
-		if (delegate != null && delegate.providesApplicationArchive(cloudModule.getLocalModule())) {
-			IModuleResource[] resources = getResources(modules);
-
-			archive = getApplicationArchive(cloudModule, monitor, delegate, resources);
-		}
+		CFApplicationArchive archive = ApplicationRegistry.getApplicationArchive(cloudModule.getLocalModule(),
+				getCloudFoundryServer().getServer(), resources, monitor);
 
 		// If no application archive was provided,then attempt an incremental
 		// publish. Incremental publish is only supported for apps without child
@@ -1786,11 +1782,7 @@ public class CloudFoundryServerBehaviour extends ServerBehaviourDelegate {
 
 	}
 
-	private CFApplicationArchive getApplicationArchive(CloudFoundryApplicationModule cloudModule,
-			IProgressMonitor monitor, AbstractApplicationDelegate delegate, IModuleResource[] resources)
-			throws CoreException {
-		return delegate.getApplicationArchive(cloudModule, getCloudFoundryServer().getServer(), resources, monitor);
-	}
+	
 
 	/**
 	 * Note that consoles may be mapped to an application's deployment name. If

--- a/org.eclipse.cft.server.core/src/org/eclipse/cft/server/core/internal/client/StartOperation.java
+++ b/org.eclipse.cft.server.core/src/org/eclipse/cft/server/core/internal/client/StartOperation.java
@@ -132,7 +132,8 @@ public class StartOperation extends RestartOperation {
 		// created in the
 		// CF server.
 
-		if (!getModules()[0].isExternal()) {
+		IModule actualModule = getModules() != null && getModules().length > 0 ? getModules()[0] : null;
+		if (actualModule != null && !actualModule.isExternal()) {
 
 			String generatingArchiveLabel = NLS.bind(Messages.CONSOLE_GENERATING_ARCHIVE,
 					appModule.getDeployedApplicationName());
@@ -148,8 +149,10 @@ public class StartOperation extends RestartOperation {
 				// An app archive must be always available, so if we reached
 				// this point and we have none
 				// then we must throw an exception.
+				String message = NLS.bind(Messages.ERROR_StartOperation_UNSUPPORTED_MODULE_TYPE, new String[] {
+						deploymentName, actualModule.getModuleType().getId(), cloudServer.getServer().getId() });
 				throw new CoreException(new Status(IStatus.ERROR, CloudFoundryPlugin.PLUGIN_ID,
-						"Application archive is not available for application: " + deploymentName)); //$NON-NLS-1$
+						message)); 
 			}
 
 			// Tell webtools the module has been published

--- a/org.eclipse.cft.server.standalone.core/src/org/eclipse/cft/server/standalone/core/internal/Messages.java
+++ b/org.eclipse.cft.server.standalone.core/src/org/eclipse/cft/server/standalone/core/internal/Messages.java
@@ -28,6 +28,8 @@ public class Messages extends NLS {
 
 	
 	public static String StandaloneConsole_PREFIX;
+	public static String DeploymentErrorHandler_ERROR_CREATE_PACKAGED_FILE;
+
 	
 	static {
 		// initialize resource bundle

--- a/org.eclipse.cft.server.standalone.core/src/org/eclipse/cft/server/standalone/core/internal/Messages.properties
+++ b/org.eclipse.cft.server.standalone.core/src/org/eclipse/cft/server/standalone/core/internal/Messages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2014, 2015 Pivotal Software, Inc. 
+# Copyright (c) 2014, 2016 Pivotal Software, Inc. 
 # 
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
@@ -21,3 +21,4 @@
 # NLS_ENCODING=UNICODE
 # NLS_MESSAGEFORMAT_VAR
 StandaloneConsole_PREFIX=[Standalone Application]
+DeploymentErrorHandler_ERROR_CREATE_PACKAGED_FILE=Failed to create packaged file

--- a/org.eclipse.cft.server.standalone.core/src/org/eclipse/cft/server/standalone/core/internal/application/CloudFoundryArchiverRegistry.java
+++ b/org.eclipse.cft.server.standalone.core/src/org/eclipse/cft/server/standalone/core/internal/application/CloudFoundryArchiverRegistry.java
@@ -22,6 +22,7 @@ package org.eclipse.cft.server.standalone.core.internal.application;
 
 import org.eclipse.cft.server.core.internal.CloudErrorUtil;
 import org.eclipse.cft.server.core.internal.CloudFoundryServer;
+import org.eclipse.cft.server.core.internal.application.ICloudFoundryArchiver;
 import org.eclipse.cft.server.core.internal.client.CloudFoundryApplicationModule;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IConfigurationElement;
@@ -29,6 +30,11 @@ import org.eclipse.core.runtime.IExtension;
 import org.eclipse.core.runtime.IExtensionPoint;
 import org.eclipse.core.runtime.Platform;
 
+/**
+ * This is deprecated. Archive registry will be moved out of standalone plugin
+ * into core plugin after CFT 1.0.1
+ */
+@Deprecated
 public class CloudFoundryArchiverRegistry {
 
 	public static final CloudFoundryArchiverRegistry INSTANCE = new CloudFoundryArchiverRegistry();
@@ -52,7 +58,6 @@ public class CloudFoundryArchiverRegistry {
 					if (ARCHIVER_ELEMENT.equals(config.getName())) {
 						ICloudFoundryArchiver archiver = (ICloudFoundryArchiver) config
 								.createExecutableExtension(CLASS_ATTR);
-						archiver.initialize(appModule.getLocalModule(), cloudServer.getServer());
 						return archiver;
 					}
 				}

--- a/org.eclipse.cft.server.standalone.core/src/org/eclipse/cft/server/standalone/core/internal/application/DeploymentErrorHandler.java
+++ b/org.eclipse.cft.server.standalone.core/src/org/eclipse/cft/server/standalone/core/internal/application/DeploymentErrorHandler.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Pivotal Software, Inc. and others
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution. 
+ * 
+ * The Eclipse Public License is available at 
+ * 
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * and the Apache License v2.0 is available at 
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * You may elect to redistribute this code under either of these licenses.
+ *  
+ *  Contributors:
+ *     Pivotal Software, Inc. - initial API and implementation
+ ********************************************************************************/
+package org.eclipse.cft.server.standalone.core.internal.application;
+
+import org.eclipse.cft.server.core.internal.CFConsoleHandler;
+import org.eclipse.cft.server.core.internal.CloudErrorUtil;
+import org.eclipse.cft.server.core.internal.CloudFoundryServer;
+import org.eclipse.cft.server.core.internal.client.CloudFoundryApplicationModule;
+import org.eclipse.cft.server.standalone.core.internal.Messages;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.wst.server.core.IModule;
+
+public class DeploymentErrorHandler {
+
+	private CFConsoleHandler consoleHandler;
+	private CloudFoundryApplicationModule appModule;
+	private IModule actualModule;
+	private CloudFoundryServer cloudServer;
+
+	public DeploymentErrorHandler(IModule actualModule, CloudFoundryApplicationModule appModule,
+			CloudFoundryServer cloudServer, CFConsoleHandler consoleHandler) {
+		this.actualModule = actualModule;
+		this.appModule = appModule;
+		this.cloudServer = cloudServer;
+		this.consoleHandler = consoleHandler;
+	}
+
+	public void handleApplicationDeploymentFailure(String errorMessage) throws CoreException {
+		if (errorMessage == null) {
+			errorMessage = Messages.DeploymentErrorHandler_ERROR_CREATE_PACKAGED_FILE;
+		}
+		errorMessage += " - " //$NON-NLS-1$
+				+ appModule.getDeployedApplicationName() + ". Unable to package application for deployment."; //$NON-NLS-1$
+		if (consoleHandler != null) {
+			consoleHandler.printErrorToConsole(actualModule, cloudServer, errorMessage);
+		}
+		throw CloudErrorUtil.toCoreException(errorMessage);
+	}
+
+	public void handleApplicationDeploymentFailure() throws CoreException {
+		handleApplicationDeploymentFailure(null);
+	}
+}

--- a/org.eclipse.cft.server.standalone.core/src/org/eclipse/cft/server/standalone/core/internal/application/StandaloneApplicationDelegate.java
+++ b/org.eclipse.cft.server.standalone.core/src/org/eclipse/cft/server/standalone/core/internal/application/StandaloneApplicationDelegate.java
@@ -26,6 +26,7 @@ import org.eclipse.cft.server.core.internal.CloudFoundryPlugin;
 import org.eclipse.cft.server.core.internal.CloudFoundryProjectUtil;
 import org.eclipse.cft.server.core.internal.CloudFoundryServer;
 import org.eclipse.cft.server.core.internal.Messages;
+import org.eclipse.cft.server.core.internal.application.ICloudFoundryArchiver;
 import org.eclipse.cft.server.core.internal.application.ModuleResourceApplicationDelegate;
 import org.eclipse.cft.server.core.internal.client.CloudFoundryApplicationModule;
 import org.eclipse.core.runtime.CoreException;
@@ -84,7 +85,7 @@ public class StandaloneApplicationDelegate extends ModuleResourceApplicationDele
 		CloudFoundryApplicationModule appModule = getCloudFoundryApplicationModule(module, server);
 		CloudFoundryServer cloudServer = getCloudServer(server);
 		ICloudFoundryArchiver archiver = CloudFoundryArchiverRegistry.INSTANCE.createArchiver(appModule, cloudServer);
-		return archiver.getApplicationArchive(monitor);
+		return archiver.getApplicationArchive(module, server, moduleResources, monitor);
 	}
 
 }

--- a/org.eclipse.cft.server.standalone.ui/src/org/eclipse/cft/server/standalone/ui/internal/Messages.java
+++ b/org.eclipse.cft.server.standalone.ui/src/org/eclipse/cft/server/standalone/ui/internal/Messages.java
@@ -42,8 +42,6 @@ public class Messages extends NLS {
 
 	public static String JavaCloudFoundryArchiver_ERROR_CREATE_CF_ARCHIVE;
 
-	public static String JavaCloudFoundryArchiver_ERROR_CREATE_PACKAGED_FILE;
-
 	public static String JavaCloudFoundryArchiver_ERROR_CREATE_TEMP_DIR;
 
 	public static String JavaCloudFoundryArchiver_ERROR_JAVA_APP_PACKAGE;

--- a/org.eclipse.cft.server.standalone.ui/src/org/eclipse/cft/server/standalone/ui/internal/Messages.properties
+++ b/org.eclipse.cft.server.standalone.ui/src/org/eclipse/cft/server/standalone/ui/internal/Messages.properties
@@ -22,7 +22,6 @@
 # NLS_MESSAGEFORMAT_VAR
 
 JavaCloudFoundryArchiver_ERROR_ARCHIVER_NOT_INITIALIZED=Archiver is not initialized
-JavaCloudFoundryArchiver_ERROR_CREATE_PACKAGED_FILE=Failed to create packaged file
 JavaCloudFoundryArchiver_ERROR_JAVA_APP_PACKAGE=Java application packaging failed - {0}
 JavaCloudFoundryArchiver_ERROR_NO_JAVA_PROJ_RESOLVED=No Java project resolved
 JavaCloudFoundryArchiver_ERROR_NO_MAIN=No main type found

--- a/org.eclipse.cft.server.standalone.ui/src/org/eclipse/cft/server/standalone/ui/internal/application/JarArchivingUIHandler.java
+++ b/org.eclipse.cft.server.standalone.ui/src/org/eclipse/cft/server/standalone/ui/internal/application/JarArchivingUIHandler.java
@@ -1,0 +1,214 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Pivotal Software, Inc. and others
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution. 
+ * 
+ * The Eclipse Public License is available at 
+ * 
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * and the Apache License v2.0 is available at 
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * You may elect to redistribute this code under either of these licenses.
+ *  
+ *  Contributors:
+ *     Pivotal Software, Inc. - initial API and implementation
+ ********************************************************************************/
+package org.eclipse.cft.server.standalone.ui.internal.application;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+
+import org.eclipse.cft.server.core.internal.CFConsoleHandler;
+import org.eclipse.cft.server.core.internal.CloudErrorUtil;
+import org.eclipse.cft.server.core.internal.CloudFoundryServer;
+import org.eclipse.cft.server.core.internal.client.CloudFoundryApplicationModule;
+import org.eclipse.cft.server.standalone.core.internal.application.DeploymentErrorHandler;
+import org.eclipse.cft.server.standalone.ui.internal.Messages;
+import org.eclipse.cft.server.ui.internal.CFUiUtil;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.SubMonitor;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.internal.ui.jarpackagerfat.FatJarRsrcUrlBuilder;
+import org.eclipse.jdt.ui.jarpackager.IJarBuilder;
+import org.eclipse.jdt.ui.jarpackager.IJarExportRunnable;
+import org.eclipse.jdt.ui.jarpackager.JarPackageData;
+import org.eclipse.osgi.util.NLS;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.wst.server.core.IModule;
+import org.springframework.boot.loader.tools.Libraries;
+import org.springframework.boot.loader.tools.Library;
+import org.springframework.boot.loader.tools.LibraryCallback;
+import org.springframework.boot.loader.tools.LibraryScope;
+import org.springframework.boot.loader.tools.Repackager;
+
+class JarArchivingUIHandler {
+
+	private CloudFoundryApplicationModule appModule;
+	private CloudFoundryServer cloudServer;
+	private CFConsoleHandler consoleHandler;
+	private DeploymentErrorHandler errorHandler;
+
+	public JarArchivingUIHandler(CloudFoundryApplicationModule appModule, CloudFoundryServer cloudServer,
+			CFConsoleHandler consoleHandler, DeploymentErrorHandler errorHandler) {
+		this.appModule = appModule;
+		this.cloudServer = cloudServer;
+		this.consoleHandler = consoleHandler;
+		this.errorHandler = errorHandler;
+	}
+
+	protected String getTempJarPath(IModule module) throws CoreException {
+		try {
+			File tempFolder = File.createTempFile("tempFolderForJavaAppJar", //$NON-NLS-1$
+					null);
+			tempFolder.delete();
+			tempFolder.mkdirs();
+
+			if (!tempFolder.exists()) {
+				throw CloudErrorUtil.toCoreException(
+						NLS.bind(Messages.JavaCloudFoundryArchiver_ERROR_CREATE_TEMP_DIR, tempFolder.getPath()));
+			}
+
+			File targetFile = new File(tempFolder, module.getName() + ".jar"); //$NON-NLS-1$
+			targetFile.deleteOnExit();
+
+			String path = new Path(targetFile.getAbsolutePath()).toString();
+
+			return path;
+
+		} catch (IOException io) {
+			CloudErrorUtil.toCoreException(io);
+		}
+		return null;
+	}
+
+	protected IJarBuilder getDefaultLibJarBuilder() {
+		return new FatJarRsrcUrlBuilder() {
+
+			public void writeRsrcUrlClasses() throws IOException {
+				// Do not unpack and repackage the Eclipse jar loader
+			}
+		};
+	}
+
+	protected JavaPackageFragmentRootHandler getPackageFragmentRootHandler(IJavaProject javaProject,
+			IProgressMonitor monitor) throws CoreException {
+
+		return new JavaPackageFragmentRootHandler(javaProject, cloudServer);
+	}
+
+	protected void bootRepackage(final IPackageFragmentRoot[] roots, File packagedFile) throws CoreException {
+		Repackager bootRepackager = new Repackager(packagedFile);
+		try {
+			bootRepackager.repackage(new Libraries() {
+
+				public void doWithLibraries(LibraryCallback callBack) throws IOException {
+					for (IPackageFragmentRoot root : roots) {
+
+						if (root.isArchive()) {
+
+							File rootFile = new File(root.getPath().toOSString());
+							if (rootFile.exists()) {
+								callBack.library(new Library(rootFile, LibraryScope.COMPILE));
+							}
+						}
+					}
+				}
+			});
+		} catch (IOException e) {
+			errorHandler.handleApplicationDeploymentFailure(
+					NLS.bind(Messages.JavaCloudFoundryArchiver_ERROR_REPACKAGE_SPRING, e.getMessage()));
+		}
+	}
+
+	protected JarPackageData getJarPackageData(IPackageFragmentRoot[] roots, IType mainType, IProgressMonitor monitor)
+			throws CoreException {
+
+		String filePath = getTempJarPath(appModule.getLocalModule());
+
+		if (filePath == null) {
+			errorHandler.handleApplicationDeploymentFailure("Failed to create temporary JAR file");
+		}
+
+		IPath location = new Path(filePath);
+
+		// Note that if no jar builder is specified in the package data
+		// then a default one is used internally by the data that does NOT
+		// package any jar dependencies.
+		JarPackageData packageData = new JarPackageData();
+
+		packageData.setJarLocation(location);
+
+		// Don't create a manifest. A repackager should determine if a
+		// generated
+		// manifest is necessary
+		// or use a user-defined manifest.
+		packageData.setGenerateManifest(false);
+
+		// Since user manifest is not used, do not save to manifest (save to
+		// manifest saves to user defined manifest)
+		packageData.setSaveManifest(false);
+
+		packageData.setManifestMainClass(mainType);
+		packageData.setElements(roots);
+		return packageData;
+	}
+
+	protected File packageApplication(final JarPackageData packageData, IProgressMonitor monitor) throws CoreException {
+
+		int progressWork = 10;
+		final SubMonitor subProgress = SubMonitor.convert(monitor, progressWork);
+
+		final File[] createdFile = new File[1];
+
+		final CoreException[] error = new CoreException[1];
+		Display.getDefault().syncExec(new Runnable() {
+
+			@Override
+			public void run() {
+				try {
+
+					Shell shell = CFUiUtil.getShell();
+
+					IJarExportRunnable runnable = packageData.createJarExportRunnable(shell);
+					try {
+						runnable.run(subProgress);
+
+						File file = new File(packageData.getJarLocation().toString());
+						if (!file.exists()) {
+							errorHandler.handleApplicationDeploymentFailure();
+						} else {
+							createdFile[0] = file;
+						}
+
+					} catch (InvocationTargetException e) {
+						throw CloudErrorUtil.toCoreException(e);
+					} catch (InterruptedException ie) {
+						throw CloudErrorUtil.toCoreException(ie);
+					} finally {
+						subProgress.done();
+					}
+				} catch (CoreException e) {
+					error[0] = e;
+				}
+			}
+
+		});
+		if (error[0] != null) {
+			throw error[0];
+		}
+
+		return createdFile[0];
+	}
+}


### PR DESCRIPTION
Application delegate framework now allows fallback to lower priority
delegates when generating archives for an application, in the event that
a higher priority delegate is unable to archive the application. Also
cleaned up code so that there are distinct archivers for different
types: file from manifest.yml, war, and jar archiving.