### PR TITLE
[498846] - Deployed URL control should be same height as other controls

### DIFF
--- a/org.eclipse.cft.server.ui/src/org/eclipse/cft/server/ui/internal/CloudApplicationUrlPart.java
+++ b/org.eclipse.cft.server.ui/src/org/eclipse/cft/server/ui/internal/CloudApplicationUrlPart.java
@@ -161,7 +161,7 @@ public class CloudApplicationUrlPart extends UIPart {
 		GridDataFactory.fillDefaults().grab(false, false).align(SWT.FILL, SWT.CENTER).applyTo(label);
 
 		fullURLText = new Text(subDomainComp, SWT.BORDER);
-		GridDataFactory.fillDefaults().grab(true, false).applyTo(fullURLText);
+		GridDataFactory.fillDefaults().grab(true, false).align(SWT.FILL, SWT.CENTER).applyTo(fullURLText);
 
 		fullURLText.addModifyListener(new ModifyListener() {
 


### PR DESCRIPTION
In the application deployment wizard on the second page, the text control for "Deployed URL" should be resized so it is same height as the other text controls on the page.
