### PR TITLE
CFT JUnit test harness clean-up of apps and services that it creates

### DIFF
--- a/org.eclipse.cft.server.tests/src/org/eclipse/cft/server/tests/core/AbstractAsynchCloudTest.java
+++ b/org.eclipse.cft.server.tests/src/org/eclipse/cft/server/tests/core/AbstractAsynchCloudTest.java
@@ -25,8 +25,8 @@ import java.lang.reflect.InvocationTargetException;
 import org.eclipse.cft.server.core.internal.CloudFoundryServer;
 import org.eclipse.cft.server.core.internal.CloudServerEvent;
 import org.eclipse.cft.server.core.internal.client.CloudFoundryApplicationModule;
-import org.eclipse.cft.server.core.internal.client.ICloudFoundryOperation;
 import org.eclipse.cft.server.tests.util.ModulesRefreshListener;
+import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
@@ -41,38 +41,6 @@ import org.eclipse.jface.operation.IRunnableWithProgress;
  *
  */
 public abstract class AbstractAsynchCloudTest extends AbstractCloudFoundryTest {
-
-	/**
-	 * Runs the given operation asynchronously in a separate Job, and waits in
-	 * the current thread for the refresh triggered by that operation to
-	 * complete. This tests the CF tooling asynch, event-driven refresh module
-	 * behaviour. When checking for the refresh to complete, it will also verify
-	 * that the expected refresh event type is the event type that was actually
-	 * received.
-	 * @param op
-	 * @param testPrefix pass null if using a module listener to detect all.
-	 * Otherwise will only listen and test against single-module refresh for
-	 * module with the corresponding app name using the prefix module refresh
-	 * @param expectedRefreshEventType
-	 * @throws CoreException
-	 */
-	protected void asynchExecuteOperation(final ICloudFoundryOperation op, String testPrefix, int expectedEventType)
-			throws Exception {
-		String expectedAppName = testPrefix != null ? harness.getWebAppName(testPrefix) : null;
-		IRunnableWithProgress runnable = new IRunnableWithProgress() {
-
-			@Override
-			public void run(IProgressMonitor monitor) throws InvocationTargetException, InterruptedException {
-				try {
-					op.run(monitor);
-				}
-				catch (CoreException e) {
-					e.printStackTrace();
-				}
-			}
-		};
-		asynchExecuteApplicationOperation(runnable, expectedAppName, expectedEventType);
-	}
 
 	/**
 	 * Runs the given operation asynchronously in a separate Job, and waits in
@@ -143,13 +111,13 @@ public abstract class AbstractAsynchCloudTest extends AbstractCloudFoundryTest {
 		refreshHandler.dispose();
 	}
 
-	protected CloudFoundryApplicationModule deployApplicationWithModuleRefresh(String appPrefix, boolean startApp,
+	protected CloudFoundryApplicationModule deployApplicationWithModuleRefresh(String appName, IProject project, boolean startApp,
 			String buildpack) throws Exception {
 
-		String appName = harness.getWebAppName(appPrefix);
 		ModulesRefreshListener listener = ModulesRefreshListener.getListener(appName, cloudServer,
 				CloudServerEvent.EVENT_APP_DEPLOYMENT_CHANGED);
-		CloudFoundryApplicationModule appModule = deployApplication(appPrefix, startApp, buildpack);
+		
+		CloudFoundryApplicationModule appModule = deployApplication(appName, project, startApp, buildpack);
 
 		assertModuleRefreshedAndDispose(listener, CloudServerEvent.EVENT_APP_DEPLOYMENT_CHANGED);
 		return appModule;

--- a/org.eclipse.cft.server.tests/src/org/eclipse/cft/server/tests/core/AbstractCloudFoundryServicesTest.java
+++ b/org.eclipse.cft.server.tests/src/org/eclipse/cft/server/tests/core/AbstractCloudFoundryServicesTest.java
@@ -123,6 +123,18 @@ public class AbstractCloudFoundryServicesTest extends AbstractAsynchCloudTest {
 		return null;
 	}
 
+	/**
+	 * Does NOT create a service. Rather, it returns the given information
+	 * (service name, plan and type) as a service instance wrapper type, IFF the
+	 * type and plan are available in the Cloud server service configuration for
+	 * that type
+	 *
+	 * @param name
+	 * @param plan
+	 * @param type
+	 * @return service instance for the given service instance information
+	 * @throws CoreException if the service type or plan are not found
+	 */
 	protected CFServiceInstance asCFServiceInstance(String name, String plan, String type) throws CoreException {
 
 		CFServiceOffering serviceConfiguration = getServiceConfiguration(type);
@@ -150,6 +162,8 @@ public class AbstractCloudFoundryServicesTest extends AbstractAsynchCloudTest {
 
 			return service;
 		}
-		return null;
+		throw CloudErrorUtil.toCoreException(
+				"No service configuration for type: " + type + " found in :" + cloudServer.getServer().getId());
+
 	}
 }

--- a/org.eclipse.cft.server.tests/src/org/eclipse/cft/server/tests/core/BehaviourOperationsTest.java
+++ b/org.eclipse.cft.server.tests/src/org/eclipse/cft/server/tests/core/BehaviourOperationsTest.java
@@ -55,13 +55,14 @@ public class BehaviourOperationsTest extends AbstractAsynchCloudTest {
 	public void testInstanceUpdate() throws Exception {
 		// Test asynchronous Application instance update and that it triggers
 		// a module refresh event
-		String prefix = "testInstanceUpdate";
+		String testName = "instanceUpdate";
 
-		String expectedAppName = harness.getWebAppName(prefix);
+		String expectedAppName = harness.getWebAppName(testName);
 
-		createWebApplicationProject();
+		IProject project = createWebApplicationProject();
 		boolean startApp = true;
-		CloudFoundryApplicationModule appModule = deployApplication(prefix, startApp, harness.getDefaultBuildpack());
+		CloudFoundryApplicationModule appModule = deployApplication(expectedAppName, project, startApp,
+				harness.getDefaultBuildpack());
 
 		assertEquals(1, appModule.getApplicationStats().getRecords().size());
 		assertEquals(1, appModule.getInstanceCount());
@@ -86,11 +87,14 @@ public class BehaviourOperationsTest extends AbstractAsynchCloudTest {
 
 	public void testMemoryUpdate() throws Exception {
 
-		String prefix = "testMemoryUpdate";
+		String testName = "memoryUpdate";
 
-		createWebApplicationProject();
+		IProject project = createWebApplicationProject();
 		boolean startApp = true;
-		CloudFoundryApplicationModule appModule = deployApplication(prefix, startApp, harness.getDefaultBuildpack());
+
+		String expectedAppName = harness.getWebAppName(testName);
+		CloudFoundryApplicationModule appModule = deployApplication(expectedAppName, project, startApp,
+				harness.getDefaultBuildpack());
 
 		final int changedMemory = 678;
 
@@ -108,13 +112,14 @@ public class BehaviourOperationsTest extends AbstractAsynchCloudTest {
 
 	public void testEnvVarUpdate() throws Exception {
 
-		String prefix = "testEnvVarUpdate";
+		String testName = "envVarUpdate";
 
-		String expectedAppName = harness.getWebAppName(prefix);
+		String expectedAppName = harness.getWebAppName(testName);
 
-		createWebApplicationProject();
+		IProject project = createWebApplicationProject();
 		boolean startApp = true;
-		CloudFoundryApplicationModule appModule = deployApplication(prefix, startApp, harness.getDefaultBuildpack());
+		CloudFoundryApplicationModule appModule = deployApplication(expectedAppName, project, startApp,
+				harness.getDefaultBuildpack());
 
 		EnvironmentVariable variable = new EnvironmentVariable();
 		variable.setVariable("JAVA_OPTS");
@@ -154,17 +159,18 @@ public class BehaviourOperationsTest extends AbstractAsynchCloudTest {
 
 	public void testAppURLUpdate() throws Exception {
 
-		String prefix = "testAppURLUpdate";
-		final String expectedAppName = harness.getWebAppName(prefix);
+		String testName = "urlUpdate";
+		final String expectedAppName = harness.getWebAppName(testName);
 
-		createWebApplicationProject();
+		IProject project = createWebApplicationProject();
 		boolean startApp = true;
-		CloudFoundryApplicationModule appModule = deployApplication(prefix, startApp, harness.getDefaultBuildpack());
+		CloudFoundryApplicationModule appModule = deployApplication(expectedAppName, project, startApp,
+				harness.getDefaultBuildpack());
 
-		String expectedURL = harness.getExpectedDefaultURL(prefix);
+		String expectedURL = harness.generateAppUrl(expectedAppName);
 		assertEquals(expectedURL, appModule.getDeploymentInfo().getUris().get(0));
 
-		String changedURL = harness.getExpectedDefaultURL("changedtestAppURLUpdate");
+		String changedURL = harness.generateAppUrl("changedtestAppURLUpdate");
 		final List<String> expectedUrls = new ArrayList<String>();
 		expectedUrls.add(changedURL);
 
@@ -179,12 +185,14 @@ public class BehaviourOperationsTest extends AbstractAsynchCloudTest {
 	}
 
 	public void testStopApplication() throws Exception {
-		String prefix = "testStopApplication";
+		String testName = "stopApp";
 
-		createWebApplicationProject();
+		IProject project = createWebApplicationProject();
 		// Deploy and start the app without the refresh listener
 		boolean startApp = true;
-		CloudFoundryApplicationModule appModule = deployApplication(prefix, startApp, harness.getDefaultBuildpack());
+		String expectedAppName = harness.getWebAppName(testName);
+		CloudFoundryApplicationModule appModule = deployApplication(expectedAppName, project, startApp,
+				harness.getDefaultBuildpack());
 
 		assertTrue("Expected application to be started",
 				appModule.getApplication().getState().equals(AppState.STARTED));
@@ -192,24 +200,23 @@ public class BehaviourOperationsTest extends AbstractAsynchCloudTest {
 		assertTrue("Expected application to be started", appModule.getRunState() == ApplicationRunState.STARTED);
 
 		// Stop the app
-		cloudServer.getBehaviour().operations().applicationDeployment(appModule, ApplicationAction.STOP)
-				.run(new NullProgressMonitor());
+		cloudServer.getBehaviour().stopModule(new IModule[] { appModule.getLocalModule() }, new NullProgressMonitor());
 
 		appModule = cloudServer.getExistingCloudModule(appModule.getDeployedApplicationName());
 
-		assertTrue("Expected application to be stopped",
-				appModule.getApplication().getState().equals(AppState.STOPPED));
+		assertTrue("Expected application to be stopped", appModule.getRunState().equals(ApplicationRunState.STOPPED));
 		assertTrue("Expected application to be stopped", appModule.getState() == Server.STATE_STOPPED);
 
 	}
 
 	public void testStartApplication() throws Exception {
 
-		String prefix = "testStartApplication";
+		String testName = "startApp";
 
-		createWebApplicationProject();
+		IProject project = createWebApplicationProject();
 		boolean startApplication = false;
-		CloudFoundryApplicationModule appModule = deployApplication(prefix, startApplication,
+		String expectedAppName = harness.getWebAppName(testName);
+		CloudFoundryApplicationModule appModule = deployApplication(expectedAppName, project, startApplication,
 				harness.getDefaultBuildpack());
 
 		assertTrue("Expected application to be stopped",
@@ -238,11 +245,13 @@ public class BehaviourOperationsTest extends AbstractAsynchCloudTest {
 
 	public void testRestartApplication() throws Exception {
 
-		String prefix = "testRestartApplication";
+		String testName = "restartApp";
 
-		createWebApplicationProject();
+		IProject project = createWebApplicationProject();
 		boolean startApp = false;
-		CloudFoundryApplicationModule appModule = deployApplication(prefix, startApp, harness.getDefaultBuildpack());
+		String expectedAppName = harness.getWebAppName(testName);
+		CloudFoundryApplicationModule appModule = deployApplication(expectedAppName, project, startApp,
+				harness.getDefaultBuildpack());
 
 		assertTrue("Expected application to be stopped",
 				appModule.getApplication().getState().equals(AppState.STOPPED));
@@ -271,12 +280,13 @@ public class BehaviourOperationsTest extends AbstractAsynchCloudTest {
 
 	public void testUpdateRestartApplication() throws Exception {
 
-		String prefix = "testUpdateRestartApplication";
+		String testName = "updateRestart";
 
-		createWebApplicationProject();
+		IProject project = createWebApplicationProject();
 
 		boolean startApplication = false;
-		CloudFoundryApplicationModule appModule = deployApplication(prefix, startApplication,
+		String expectedAppName = harness.getWebAppName(testName);
+		CloudFoundryApplicationModule appModule = deployApplication(expectedAppName, project, startApplication,
 				harness.getDefaultBuildpack());
 
 		assertTrue("Expected application to be stopped",
@@ -305,14 +315,14 @@ public class BehaviourOperationsTest extends AbstractAsynchCloudTest {
 
 	public void testApplicationStopState() throws Exception {
 
-		String prefix = "testApplicationStopState";
-		String expectedAppName = harness.getWebAppName(prefix);
+		String testName = "stopState";
+		String expectedAppName = harness.getWebAppName(testName);
 		IProject project = createWebApplicationProject();
 		boolean startApp = false;
 		getTestFixture().configureForApplicationDeployment(expectedAppName,
 				CloudFoundryTestUtil.DEFAULT_TEST_APP_MEMORY, startApp);
 
-		IModule module = getModule(project.getName());
+		IModule module = getWstModule(project.getName());
 
 		cloudServer.getBehaviour().operations().applicationDeployment(new IModule[] { module }, ApplicationAction.PUSH)
 				.run(new NullProgressMonitor());
@@ -340,15 +350,15 @@ public class BehaviourOperationsTest extends AbstractAsynchCloudTest {
 
 	public void testApplicationStartState() throws Exception {
 
-		String prefix = "testApplicationStartState";
+		String testName = "startState";
 
-		String expectedAppName = harness.getWebAppName(prefix);
+		String expectedAppName = harness.getWebAppName(testName);
 		IProject project = createWebApplicationProject();
 		boolean startApp = true;
 
 		getTestFixture().configureForApplicationDeployment(expectedAppName, startApp);
 
-		IModule module = getModule(project.getName());
+		IModule module = getWstModule(project.getName());
 
 		cloudServer.getBehaviour().operations().applicationDeployment(new IModule[] { module }, ApplicationAction.PUSH)
 				.run(new NullProgressMonitor());

--- a/org.eclipse.cft.server.tests/src/org/eclipse/cft/server/tests/core/CloudFoundryProxyTest.java
+++ b/org.eclipse.cft.server.tests/src/org/eclipse/cft/server/tests/core/CloudFoundryProxyTest.java
@@ -37,6 +37,7 @@ import org.eclipse.cft.server.tests.sts.util.ProxyHandler;
 import org.eclipse.cft.server.tests.util.ModulesRefreshListener;
 import org.eclipse.core.net.proxy.IProxyData;
 import org.eclipse.core.net.proxy.IProxyService;
+import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.wst.server.core.IModule;
 import org.eclipse.wst.server.core.IServer;
@@ -94,11 +95,14 @@ public class CloudFoundryProxyTest extends AbstractAsynchCloudTest {
 
 		// Verify that connection and operations can be performed without the
 		// proxy change
-		String prefix = "InvalidProxyServerInstance";
-		createWebApplicationProject();
+		String testName = "InvalidProxyServerInstance";
+		IProject project = createWebApplicationProject();
 
 		boolean startApp = true;
-		CloudFoundryApplicationModule appModule = deployApplication(prefix, startApp, harness.getDefaultBuildpack());
+
+		String expectedAppName = harness.getWebAppName(testName);
+		CloudFoundryApplicationModule appModule = deployApplication(expectedAppName, project, startApp,
+				harness.getDefaultBuildpack());
 
 		final String appName = appModule.getDeployedApplicationName();
 

--- a/org.eclipse.cft.server.tests/src/org/eclipse/cft/server/tests/core/ModuleRefreshTest.java
+++ b/org.eclipse.cft.server.tests/src/org/eclipse/cft/server/tests/core/ModuleRefreshTest.java
@@ -64,8 +64,8 @@ public class ModuleRefreshTest extends AbstractAsynchCloudTest {
 		// which the behaviour uses is tested separately in a different test
 		// case
 
-		String prefix = "testUMSBECApp";
-		String expectedAppName = harness.getWebAppName(prefix);
+		String testName = "refreshExisting";
+		String expectedAppName = harness.getWebAppName(testName);
 
 		// Create the app externally AFTER the server connects in the setup to
 		// ensure the tools did not pick up the Cloud application during refresh
@@ -73,7 +73,7 @@ public class ModuleRefreshTest extends AbstractAsynchCloudTest {
 		client.login();
 
 		List<String> urls = new ArrayList<String>();
-		urls.add(harness.getExpectedDefaultURL(prefix));
+		urls.add(harness.generateAppUrl(expectedAppName));
 		client.createApplication(expectedAppName, new Staging(), CloudFoundryTestUtil.DEFAULT_TEST_APP_MEMORY, urls,
 				new ArrayList<String>());
 
@@ -103,8 +103,8 @@ public class ModuleRefreshTest extends AbstractAsynchCloudTest {
 		// which the behaviour uses is tested separately in a different test
 		// case
 
-		String prefix = "testUpdateModuleInstances";
-		String expectedAppName = harness.getWebAppName(prefix);
+		String testName = "updateModules";
+		String expectedAppName = harness.getWebAppName(testName);
 
 		// Create the app externally AFTER the server connects in the setup to
 		// ensure the tools did not pick up the Cloud application during refresh
@@ -112,7 +112,7 @@ public class ModuleRefreshTest extends AbstractAsynchCloudTest {
 		client.login();
 
 		List<String> urls = new ArrayList<String>();
-		urls.add(harness.getExpectedDefaultURL(prefix));
+		urls.add(harness.generateAppUrl(expectedAppName));
 		client.createApplication(expectedAppName, new Staging(), CloudFoundryTestUtil.DEFAULT_TEST_APP_MEMORY, urls,
 				new ArrayList<String>());
 
@@ -158,8 +158,8 @@ public class ModuleRefreshTest extends AbstractAsynchCloudTest {
 		// Server
 		// which the behaviour uses is tested separately in a different test
 		// case
-		String prefix = "testUMSBWCApp";
-		String expectedAppName = harness.getWebAppName(prefix);
+		String testName = "updateWrongApp";
+		String expectedAppName = harness.getWebAppName(testName);
 
 		// Create the app externally AFTER the server connects in the setup to
 		// ensure the tools did not pick up the Cloud application during refresh
@@ -167,7 +167,7 @@ public class ModuleRefreshTest extends AbstractAsynchCloudTest {
 		client.login();
 
 		List<String> urls = new ArrayList<String>();
-		urls.add(harness.getExpectedDefaultURL(prefix));
+		urls.add(harness.generateAppUrl(expectedAppName));
 		client.createApplication(expectedAppName, new Staging(), CloudFoundryTestUtil.DEFAULT_TEST_APP_MEMORY, urls,
 				new ArrayList<String>());
 
@@ -190,8 +190,8 @@ public class ModuleRefreshTest extends AbstractAsynchCloudTest {
 		// an existing
 		// CloudFoundryApplicationModule ONLY if it is given a CloudApplication.
 
-		String prefix = "testUpdateModulesCloudServer";
-		String expectedAppName = harness.getWebAppName(prefix);
+		String testName = "updateCloudServer";
+		String expectedAppName = harness.getWebAppName(testName);
 
 		// Create the app externally AFTER the server connects in the setup to
 		// ensure the tools did not pick up the Cloud application during refresh
@@ -199,7 +199,7 @@ public class ModuleRefreshTest extends AbstractAsynchCloudTest {
 		client.login();
 
 		List<String> urls = new ArrayList<String>();
-		urls.add(harness.getExpectedDefaultURL(prefix));
+		urls.add(harness.generateAppUrl(expectedAppName));
 		client.createApplication(expectedAppName, new Staging(), CloudFoundryTestUtil.DEFAULT_TEST_APP_MEMORY, urls,
 				new ArrayList<String>());
 
@@ -216,10 +216,13 @@ public class ModuleRefreshTest extends AbstractAsynchCloudTest {
 		appModule = cloudServer.updateModule(null, null, null, new NullProgressMonitor());
 		assertNull(appModule);
 
-		assertTrue(cloudServer.getExistingCloudModules().isEmpty());
+		// Once again check that existing module does not return anything as no
+		// refresh or update has occurred.
+		appModule = cloudServer.getExistingCloudModule(expectedAppName);
+		assertNull(appModule);
 
 		// Get the actual cloud app directly from the Cloud space
-		CloudApplication actualApp = client.getApplications().get(0);
+		CloudApplication actualApp = getAppFromExternalClient(expectedAppName);
 		ApplicationStats stats = client.getApplicationStats(actualApp.getName());
 
 		// Now create the CloudFoundryApplicationModule
@@ -246,9 +249,8 @@ public class ModuleRefreshTest extends AbstractAsynchCloudTest {
 		assertEquals(CloudFoundryTestUtil.DEFAULT_TEST_APP_MEMORY, existingCloudMod.getApplication().getMemory());
 		assertEquals(existingCloudMod.getDeploymentInfo().getMemory(), existingCloudMod.getApplication().getMemory());
 
-		// Check the other existing Modules API
-		CloudFoundryApplicationModule sameExistingApp = cloudServer.getExistingCloudModules().iterator().next();
-		assertEquals(expectedAppName, sameExistingApp.getDeployedApplicationName());
+		CloudFoundryApplicationModule sameExistingApp = cloudServer.getExistingCloudModule(expectedAppName);
+		assertNotNull(sameExistingApp);
 		assertEquals(sameExistingApp.getDeployedApplicationName(), sameExistingApp.getApplication().getName());
 
 		// Check the mapping is correct
@@ -272,8 +274,8 @@ public class ModuleRefreshTest extends AbstractAsynchCloudTest {
 		// 3. Update the application externally and refresh all Modules - Module
 		// and mapping to CloudApplication should be updated.
 
-		String prefix = "testMUExternalChanges";
-		String appName = harness.getWebAppName(prefix);
+		String testName = "updateExternal";
+		String appName = harness.getWebAppName(testName);
 		IProject project = createWebApplicationProject();
 
 		boolean stopMode = false;
@@ -283,7 +285,7 @@ public class ModuleRefreshTest extends AbstractAsynchCloudTest {
 		getTestFixture().configureForApplicationDeployment(appName, CloudFoundryTestUtil.DEFAULT_TEST_APP_MEMORY,
 				stopMode);
 
-		IModule module = getModule(project.getName());
+		IModule module = getWstModule(project.getName());
 
 		// Push the application
 		cloudServer.getBehaviour().operations().applicationDeployment(new IModule[] { module }, ApplicationAction.PUSH)
@@ -381,8 +383,8 @@ public class ModuleRefreshTest extends AbstractAsynchCloudTest {
 
 	public void testSingleModuleUpdateExternalAppDeletion() throws Exception {
 
-		String prefix = "testSMUEAppDeletion";
-		String appName = harness.getWebAppName(prefix);
+		String testName = "externalAppDeletion";
+		String appName = harness.getWebAppName(testName);
 		IProject project = createWebApplicationProject();
 
 		boolean stopMode = false;
@@ -392,7 +394,7 @@ public class ModuleRefreshTest extends AbstractAsynchCloudTest {
 		getTestFixture().configureForApplicationDeployment(appName, CloudFoundryTestUtil.DEFAULT_TEST_APP_MEMORY,
 				stopMode);
 
-		IModule module = getModule(project.getName());
+		IModule module = getWstModule(project.getName());
 
 		// Push the application.
 		cloudServer.getBehaviour().operations().applicationDeployment(new IModule[] { module }, ApplicationAction.PUSH)
@@ -427,10 +429,10 @@ public class ModuleRefreshTest extends AbstractAsynchCloudTest {
 
 	}
 
-	public void testSingleModuleUpdateNonExistantApp() throws Exception {
+	public void testSingleModuleUpdateNonExistingApp() throws Exception {
 
-		String prefix = "testSMUNonExistantApp";
-		String appName = harness.getWebAppName(prefix);
+		String testName = "nonExistingAPp";
+		String appName = harness.getWebAppName(testName);
 		IProject project = createWebApplicationProject();
 
 		boolean stopMode = false;
@@ -440,7 +442,7 @@ public class ModuleRefreshTest extends AbstractAsynchCloudTest {
 		getTestFixture().configureForApplicationDeployment(appName, CloudFoundryTestUtil.DEFAULT_TEST_APP_MEMORY,
 				stopMode);
 
-		IModule module = getModule(project.getName());
+		IModule module = getWstModule(project.getName());
 
 		CloudFoundryApplicationModule appModule = cloudServer.getExistingCloudModule(appName);
 
@@ -473,8 +475,8 @@ public class ModuleRefreshTest extends AbstractAsynchCloudTest {
 
 	public void testSingleModuleUpdateExternalCreation() throws Exception {
 
-		String prefix = "testSMUECreation";
-		String appName = harness.getWebAppName(prefix);
+		String testName = "externalApp";
+		String appName = harness.getWebAppName(testName);
 
 		// After deployment the module must exist and be mapped to an existing
 		// CloudApplication
@@ -489,7 +491,7 @@ public class ModuleRefreshTest extends AbstractAsynchCloudTest {
 		client.login();
 
 		List<String> urls = new ArrayList<String>();
-		urls.add(harness.getExpectedDefaultURL(prefix));
+		urls.add(harness.generateAppUrl(appName));
 		client.createApplication(appName, new Staging(), CloudFoundryTestUtil.DEFAULT_TEST_APP_MEMORY, urls,
 				new ArrayList<String>());
 
@@ -503,8 +505,8 @@ public class ModuleRefreshTest extends AbstractAsynchCloudTest {
 
 	public void testAllModuleUpdateExternalCreation() throws Exception {
 
-		String prefix = "testAMUExternalCreation";
-		String appName = harness.getWebAppName(prefix);
+		String testName = "externalApps";
+		String appName = harness.getWebAppName(testName);
 
 		CloudFoundryApplicationModule appModule = cloudServer.getExistingCloudModule(appName);
 		assertNull(appModule);
@@ -517,7 +519,7 @@ public class ModuleRefreshTest extends AbstractAsynchCloudTest {
 		client.login();
 
 		List<String> urls = new ArrayList<String>();
-		urls.add(harness.getExpectedDefaultURL(prefix));
+		urls.add(harness.generateAppUrl(appName));
 		client.createApplication(appName, new Staging(), CloudFoundryTestUtil.DEFAULT_TEST_APP_MEMORY, urls,
 				new ArrayList<String>());
 
@@ -551,11 +553,12 @@ public class ModuleRefreshTest extends AbstractAsynchCloudTest {
 	public void testScheduleRefreshHandlerAllModules() throws Exception {
 		// Tests both the CloudFoundryServerBehaviour refresh handler as well as
 		// the test harness refresh listener
-		String prefix = "testSRHAModules";
-		createWebApplicationProject();
+		String testName = "refreshAll";
+		IProject project = createWebApplicationProject();
 
 		boolean startApp = true;
-		deployApplicationWithModuleRefresh(prefix, startApp, harness.getDefaultBuildpack());
+		String expectedAppName = harness.getWebAppName(testName);
+		deployApplicationWithModuleRefresh(expectedAppName, project, startApp, harness.getDefaultBuildpack());
 
 		// Test the server-wide refresh of all modules without specifying a
 		// selected module.
@@ -583,11 +586,12 @@ public class ModuleRefreshTest extends AbstractAsynchCloudTest {
 	public void testScheduleRefreshHandlerRefreshApplication() throws Exception {
 		// Tests both the CloudFoundryServerBehaviour refresh handler as well as
 		// the test harness refresh listener
-		String prefix = "testSRHRefreshApplication";
-		createWebApplicationProject();
+		String testName = "refreshApp";
+		IProject project = createWebApplicationProject();
 
 		boolean startApp = true;
-		CloudFoundryApplicationModule appModule = deployApplicationWithModuleRefresh(prefix, startApp,
+		String expectedAppName = harness.getWebAppName(testName);
+		CloudFoundryApplicationModule appModule = deployApplicationWithModuleRefresh(expectedAppName, project, startApp,
 				harness.getDefaultBuildpack());
 
 		ModulesRefreshListener refreshListener = ModulesRefreshListener.getListener(
@@ -600,11 +604,13 @@ public class ModuleRefreshTest extends AbstractAsynchCloudTest {
 
 	public void testScheduleRefreshHandlerAllModuleInstances() throws Exception {
 
-		String prefix = "testSRHAMInstances";
-		createWebApplicationProject();
+		String testName = "refreshAll2";
+		IProject project = createWebApplicationProject();
 
 		boolean startApp = true;
-		deployApplicationWithModuleRefresh(prefix, startApp, harness.getDefaultBuildpack());
+
+		String expectedAppName = harness.getWebAppName(testName);
+		deployApplicationWithModuleRefresh(expectedAppName, project, startApp, harness.getDefaultBuildpack());
 
 		ModulesRefreshListener refreshListener = ModulesRefreshListener.getListener(null, cloudServer,
 				CloudServerEvent.EVENT_UPDATE_COMPLETED);
@@ -616,11 +622,13 @@ public class ModuleRefreshTest extends AbstractAsynchCloudTest {
 
 	public void testScheduleRefreshHandlerDeploymentChange() throws Exception {
 
-		String prefix = "testSRHDChange";
-		createWebApplicationProject();
+		String testName = "deploymentChange";
+		IProject project = createWebApplicationProject();
 
 		boolean startApp = true;
-		CloudFoundryApplicationModule appModule = deployApplicationWithModuleRefresh(prefix, startApp,
+		String expectedAppName = harness.getWebAppName(testName);
+
+		CloudFoundryApplicationModule appModule = deployApplicationWithModuleRefresh(expectedAppName, project, startApp,
 				harness.getDefaultBuildpack());
 
 		ModulesRefreshListener refreshListener = ModulesRefreshListener.getListener(null, cloudServer,
@@ -634,13 +642,13 @@ public class ModuleRefreshTest extends AbstractAsynchCloudTest {
 	public void testApplicationRefreshedEvent() throws Exception {
 		// Tests the general event handler
 
-		String prefix = "testApplicationRefreshedEvent";
-		createWebApplicationProject();
+		String testName = "refreshEvent";
+		IProject project = createWebApplicationProject();
 
-		String expectedAppName = harness.getWebAppName(prefix);
+		String expectedAppName = harness.getWebAppName(testName);
 
 		boolean startApp = true;
-		deployApplicationWithModuleRefresh(prefix, startApp, harness.getDefaultBuildpack());
+		deployApplicationWithModuleRefresh(expectedAppName, project, startApp, harness.getDefaultBuildpack());
 
 		final IModule module = cloudServer.getExistingCloudModule(expectedAppName).getLocalModule();
 
@@ -661,19 +669,20 @@ public class ModuleRefreshTest extends AbstractAsynchCloudTest {
 	}
 
 	public void testModuleRefreshDuringServerConnect1() throws Exception {
-		String appPrefix = "testModuleRDServerConnect1";
-		createWebApplicationProject();
+		String testName = "refreshOnConnect";
+		IProject project = createWebApplicationProject();
+		String expectedAppName = harness.getWebAppName(testName);
 
 		boolean startApp = true;
-		deployApplicationWithModuleRefresh(appPrefix, startApp, harness.getDefaultBuildpack());
+		deployApplicationWithModuleRefresh(expectedAppName, project, startApp, harness.getDefaultBuildpack());
 
 		// Cloud module should have been created.
-		Collection<CloudFoundryApplicationModule> appModules = cloudServer.getExistingCloudModules();
-		assertEquals(harness.getWebAppName(appPrefix), appModules.iterator().next().getDeployedApplicationName());
+		CloudFoundryApplicationModule refreshedModule = cloudServer.getExistingCloudModule(expectedAppName);
+		assertEquals(expectedAppName, refreshedModule.getDeployedApplicationName());
 
 		serverBehavior.disconnect(new NullProgressMonitor());
 
-		appModules = cloudServer.getExistingCloudModules();
+		Collection<CloudFoundryApplicationModule> appModules = cloudServer.getExistingCloudModules();
 
 		assertTrue("Expected empty list of cloud application modules after server disconnect", appModules.isEmpty());
 
@@ -684,8 +693,8 @@ public class ModuleRefreshTest extends AbstractAsynchCloudTest {
 
 		assertModuleRefreshedAndDispose(listener, CloudServerEvent.EVENT_UPDATE_COMPLETED);
 
-		appModules = cloudServer.getExistingCloudModules();
-		assertEquals(harness.getWebAppName(appPrefix), appModules.iterator().next().getDeployedApplicationName());
+		refreshedModule = cloudServer.getExistingCloudModule(expectedAppName);
+		assertEquals(expectedAppName, refreshedModule.getDeployedApplicationName());
 	}
 
 	public void testModuleRefreshDuringServerConnect2() throws Exception {
@@ -697,10 +706,10 @@ public class ModuleRefreshTest extends AbstractAsynchCloudTest {
 		// disconnecting
 		// the server should not stop the application).
 
-		String appPrefix = "testModuleRDServerConnect2";
-		String expectedAppName = harness.getWebAppName(appPrefix);
+		String testName = "refreshOnConnect2";
+		String expectedAppName = harness.getWebAppName(testName);
 
-		createWebApplicationProject();
+		IProject project = createWebApplicationProject();
 
 		// Note that deploying application fires off an app change event AFTER
 		// the deployment is
@@ -711,28 +720,22 @@ public class ModuleRefreshTest extends AbstractAsynchCloudTest {
 		// schedule the second listener to
 		// listen to the expected refresh event
 		boolean startApp = true;
-		deployApplicationWithModuleRefresh(appPrefix, startApp, harness.getDefaultBuildpack());
+		deployApplicationWithModuleRefresh(expectedAppName, project, startApp, harness.getDefaultBuildpack());
 
 		// Cloud module should have been created.
-		Collection<CloudFoundryApplicationModule> appModules = cloudServer.getExistingCloudModules();
-		assertEquals(harness.getWebAppName(appPrefix), appModules.iterator().next().getDeployedApplicationName());
+		CloudFoundryApplicationModule refreshedModule = cloudServer.getExistingCloudModule(expectedAppName);
+		assertEquals(expectedAppName, refreshedModule.getDeployedApplicationName());
 
 		// Disconnect and verify that there are no cloud foundry application
 		// modules
 		serverBehavior.disconnect(new NullProgressMonitor());
-		appModules = cloudServer.getExistingCloudModules();
+		Collection<CloudFoundryApplicationModule> appModules = cloudServer.getExistingCloudModules();
 		assertTrue("Expected empty list of cloud application modules after server disconnect", appModules.isEmpty());
 
-		// Now create an external client to independently check that the
-		// application remains deployed and in started mode
-
-		CloudFoundryOperations client = getTestFixture().createExternalClient();
-		client.login();
-		List<CloudApplication> deployedApplications = client.getApplications();
-		assertEquals("Expected 1 Cloud application in Cloud space after server disconnect", 1,
-				deployedApplications.size());
-		assertEquals(expectedAppName, deployedApplications.get(0).getName());
-		assertTrue(deployedApplications.get(0).getState() == AppState.STARTED);
+		// Check that app still exists via external client (i.e. the disconnect did not delete the actual app in CF)
+		CloudApplication deployedApp = getAppFromExternalClient(expectedAppName);
+		assertEquals(expectedAppName, deployedApp.getName());
+		assertTrue(deployedApp.getState() == AppState.STARTED);
 
 		// Register a module refresh listener before connecting again to be
 		// notified when
@@ -744,8 +747,7 @@ public class ModuleRefreshTest extends AbstractAsynchCloudTest {
 
 		assertModuleRefreshedAndDispose(listener, CloudServerEvent.EVENT_UPDATE_COMPLETED);
 
-		appModules = cloudServer.getExistingCloudModules();
-		CloudFoundryApplicationModule appModule = appModules.iterator().next();
+		CloudFoundryApplicationModule appModule = cloudServer.getExistingCloudModule(expectedAppName);
 
 		assertEquals(expectedAppName, appModule.getDeployedApplicationName());
 	}


### PR DESCRIPTION
Only delete apps, services and routes that the test harness creates.
Avoid deleting any other apps and services in the Cloud space not
associated with running the CFT JUnit tests.
Also cleaned up the test harness API so that their contracts are
clearer.