### PR TITLE
[501186] - Unpublished modules are updated on operation cancellation.

### DIFF
--- a/org.eclipse.cft.server.core/src/org/eclipse/cft/server/core/internal/CloudErrorUtil.java
+++ b/org.eclipse.cft.server.core/src/org/eclipse/cft/server/core/internal/CloudErrorUtil.java
@@ -463,4 +463,8 @@ public class CloudErrorUtil {
 		return cfe.getMessage();
 	}
 
+	public static String getMessage(CoreException ce) {
+		return ce.getMessage();
+	}
+
 }

--- a/org.eclipse.cft.server.core/src/org/eclipse/cft/server/core/internal/CloudFoundryServer.java
+++ b/org.eclipse.cft.server.core/src/org/eclipse/cft/server/core/internal/CloudFoundryServer.java
@@ -1239,7 +1239,7 @@ public class CloudFoundryServer extends ServerDelegate implements IURLProvider {
 						deleteModule(wstModule);
 					}
 
-					// Remove the cloud module from the catch
+					// Remove the cloud module from the cache
 					if (correspondingCloudModule != null) {
 						getData().remove(correspondingCloudModule);
 						correspondingCloudModule = null;

--- a/org.eclipse.cft.server.core/src/org/eclipse/cft/server/core/internal/client/AbstractPublishApplicationOperation.java
+++ b/org.eclipse.cft.server.core/src/org/eclipse/cft/server/core/internal/client/AbstractPublishApplicationOperation.java
@@ -91,36 +91,7 @@ public abstract class AbstractPublishApplicationOperation extends BehaviourOpera
 			getBehaviour().asyncUpdateModuleAfterPublish(getModule());
 		}
 		catch (OperationCanceledException e) {
-			// [492609] - Modules are not correctly marked as "completed" when
-			// cancellation occurs.
-			// This results in the internal server module cache going out of
-			// synch with Cloud Foundry. By telling the cache that module addition has been completed, the cache
-			// can be correctly removed
-			getBehaviour().getCloudFoundryServer().moduleAdditionCompleted(getModule());
-			
-			// ignore so webtools does not show an exception
-			((Server) getBehaviour().getServer()).setModuleState(getModules(), IServer.STATE_UNKNOWN);
-
-			// If application operations, like Restart, Start, or
-			// PushApplication are canceled, then the publish state is
-			// 'indeterminate'
-			// TODO: Don't reference internal Server class. We need to revisit
-			// this change and revert back to the original state.
-			((Server) getBehaviour().getServer()).setServerPublishState(IServer.PUBLISH_STATE_INCREMENTAL);
-			((Server) getBehaviour().getServer()).setModulePublishState(modules, IServer.PUBLISH_STATE_INCREMENTAL);
-
-			// Record the canceled operation 'description' to the log file.
-			CloudFoundryPlugin.logWarning(e.getMessage());
-
-			CloudFoundryServer cloudServer = getBehaviour().getCloudFoundryServer();
-
-			CloudFoundryApplicationModule appModule = cloudServer.getExistingCloudModule(getModule());
-			if (appModule != null && e.getMessage() != null) {
-				CloudFoundryPlugin.getCallback().printToConsole(cloudServer, appModule,
-						NLS.bind(Messages.AbstractPublishApplicationOperation_OPERATION_CANCELED, e.getMessage())
-								+ '\n',
-						false, false);
-			}
+			cancelPublish(monitor, e);
 		}
 		catch (Throwable e) {
 
@@ -155,6 +126,49 @@ public abstract class AbstractPublishApplicationOperation extends BehaviourOpera
 			throw e;
 		}
 
+	}
+
+	protected void cancelPublish(IProgressMonitor monitor, OperationCanceledException e) throws CoreException {
+		// Record the canceled operation 'description' to the log file and console first as the module is still available
+		// at this stage. It may be delete later in the cancellation during an update if the associated CF app does not exist.
+		CloudFoundryPlugin.logWarning(e.getMessage());
+
+		CloudFoundryServer cloudServer = getBehaviour().getCloudFoundryServer();
+		CloudFoundryApplicationModule appModule = cloudServer.getExistingCloudModule(getModule());
+		if (appModule != null && e.getMessage() != null) {
+			CloudFoundryPlugin.getCallback().printToConsole(cloudServer, appModule,
+					NLS.bind(Messages.AbstractPublishApplicationOperation_OPERATION_CANCELED, e.getMessage()) + '\n',
+					false, false);
+		}
+		
+		// Bug 492609 - Modules are not correctly marked as "completed" when
+		// cancellation occurs.
+		// This results in the internal server module cache going out of
+		// synch with Cloud Foundry. By telling the cache that module addition
+		// has been completed, the cache
+		// can be correctly removed
+		getBehaviour().getCloudFoundryServer().moduleAdditionCompleted(getModule());
+		
+		// Allow subclasses to react to the cancelled publish operation
+		onOperationCanceled(e, monitor);
+
+		// The following steps should be standard to all publish operations in terms of setting the server state
+		// ignore so webtools does not show an exception
+		((Server) getBehaviour().getServer()).setModuleState(getModules(), IServer.STATE_UNKNOWN);
+
+		// If application operations, like Restart, Start, or
+		// PushApplication are canceled, then the publish state is
+		// 'indeterminate'
+		// TODO: Don't reference internal Server class. We need to revisit
+		// this change and revert back to the original state.
+		((Server) getBehaviour().getServer()).setServerPublishState(IServer.PUBLISH_STATE_INCREMENTAL);
+		((Server) getBehaviour().getServer()).setModulePublishState(modules, IServer.PUBLISH_STATE_INCREMENTAL);
+	}
+
+
+	protected void onOperationCanceled(OperationCanceledException e, IProgressMonitor monitor) throws CoreException {
+		// Hook to allow specialised publish operations to react to operation
+		// canceled.
 	}
 
 	protected abstract void doApplicationOperation(IProgressMonitor monitor) throws CoreException;

--- a/org.eclipse.cft.server.core/src/org/eclipse/cft/server/core/internal/client/AbstractPublishApplicationOperation.java
+++ b/org.eclipse.cft.server.core/src/org/eclipse/cft/server/core/internal/client/AbstractPublishApplicationOperation.java
@@ -91,7 +91,7 @@ public abstract class AbstractPublishApplicationOperation extends BehaviourOpera
 			getBehaviour().asyncUpdateModuleAfterPublish(getModule());
 		}
 		catch (OperationCanceledException e) {
-			cancelPublish(monitor, e);
+			cancelPublish(e, monitor);
 		}
 		catch (Throwable e) {
 
@@ -128,7 +128,7 @@ public abstract class AbstractPublishApplicationOperation extends BehaviourOpera
 
 	}
 
-	protected void cancelPublish(IProgressMonitor monitor, OperationCanceledException e) throws CoreException {
+	protected void cancelPublish(OperationCanceledException e, IProgressMonitor monitor) throws CoreException {
 		// Record the canceled operation 'description' to the log file and console first as the module is still available
 		// at this stage. It may be delete later in the cancellation during an update if the associated CF app does not exist.
 		CloudFoundryPlugin.logWarning(e.getMessage());
@@ -149,7 +149,7 @@ public abstract class AbstractPublishApplicationOperation extends BehaviourOpera
 		// can be correctly removed
 		getBehaviour().getCloudFoundryServer().moduleAdditionCompleted(getModule());
 		
-		// Allow subclasses to react to the cancelled publish operation
+		// Allow subclasses to react to the canceled publish operation
 		onOperationCanceled(e, monitor);
 
 		// The following steps should be standard to all publish operations in terms of setting the server state

--- a/org.eclipse.cft.server.ui/src/org/eclipse/cft/server/ui/internal/actions/EditorAction.java
+++ b/org.eclipse.cft.server.ui/src/org/eclipse/cft/server/ui/internal/actions/EditorAction.java
@@ -23,7 +23,6 @@ package org.eclipse.cft.server.ui.internal.actions;
 import org.cloudfoundry.client.lib.CloudFoundryException;
 import org.cloudfoundry.client.lib.NotFinishedStagingException;
 import org.eclipse.cft.server.core.internal.CloudErrorUtil;
-import org.eclipse.cft.server.core.internal.CloudFoundryPlugin;
 import org.eclipse.cft.server.core.internal.CloudFoundryServer;
 import org.eclipse.cft.server.core.internal.CloudServerEvent;
 import org.eclipse.cft.server.core.internal.ServerEventHandler;
@@ -190,19 +189,6 @@ public abstract class EditorAction extends Action {
 	 */
 	protected IStatus display404Error(IStatus status) {
 		return status;
-	}
-
-	protected void setErrorInPage(IStatus status) {
-		setErrorInPage(status.getMessage());
-	}
-
-	protected void setErrorInPage(String message) {
-		IStatus errorStatus = message != null ? CloudFoundryPlugin.getErrorStatus(message) : null;
-		setMessageInPage(errorStatus);
-	}
-
-	protected void setMessageInPage(IStatus status) {
-		editorPage.setMessage(status);
 	}
 
 	protected CloudFoundryServerBehaviour getBehaviour() {

--- a/org.eclipse.cft.server.ui/src/org/eclipse/cft/server/ui/internal/editor/ApplicationDetailsPart.java
+++ b/org.eclipse.cft.server.ui/src/org/eclipse/cft/server/ui/internal/editor/ApplicationDetailsPart.java
@@ -1038,11 +1038,16 @@ public class ApplicationDetailsPart extends AbstractFormPart implements IDetails
 		debugButton.setData(DebugOperationType.Debug);
 		debugButton.addSelectionListener(new SelectionAdapter() {
 			public void widgetSelected(SelectionEvent e) {
-				if (DebugOperationType.Debug.equals(debugButton.getData())) {
-					debug();
+				try {
+					if (DebugOperationType.Debug.equals(debugButton.getData())) {
+						debug();
+					}
+					else if (DebugOperationType.Terminate.equals(debugButton.getData())) {
+						terminateDebug();
+					}
 				}
-				else if (DebugOperationType.Terminate.equals(debugButton.getData())) {
-					terminateDebug();
+				catch (CoreException ce) {
+					logApplicationModuleFailureError(CloudErrorUtil.getMessage(ce));
 				}
 			}
 		});
@@ -1293,6 +1298,7 @@ public class ApplicationDetailsPart extends AbstractFormPart implements IDetails
 
 		return appModule;
 	}
+	
 
 	protected void logError(String message) {
 		logError(message, null);
@@ -1313,8 +1319,8 @@ public class ApplicationDetailsPart extends AbstractFormPart implements IDetails
 		}
 	}
 
-	protected void debug() {
-		CloudFoundryApplicationModule appModule = cloudServer.getExistingCloudModule(module);
+	protected void debug() throws CoreException {
+		CloudFoundryApplicationModule appModule = getExistingApplication();
 
 		if (appModule != null) {
 			new DebugApplicationEditorAction(editorPage, appModule, cloudServer, getSelectedAppInstance(),
@@ -1322,8 +1328,8 @@ public class ApplicationDetailsPart extends AbstractFormPart implements IDetails
 		}
 	}
 
-	protected void terminateDebug() {
-		CloudFoundryApplicationModule appModule = cloudServer.getExistingCloudModule(module);
+	protected void terminateDebug() throws CoreException {
+		CloudFoundryApplicationModule appModule = getExistingApplication();
 
 		if (appModule != null) {
 			new TerminateDebugEditorAction(editorPage, appModule, cloudServer, getSelectedAppInstance(), debugLauncher)


### PR DESCRIPTION
When a publish operation is cancelled, the unpublished module is now
updated (and indirectly deleted) from the server, if the CF app does not
actually exist.